### PR TITLE
(fix) sigma計算のバグ改修

### DIFF
--- a/src/Calc_Correct_Param.py
+++ b/src/Calc_Correct_Param.py
@@ -79,10 +79,10 @@ def Calc_Correct_Pram(X_NUM, X_CAL, dat_set):
         # 文字の置き換え
         expression = X_CAL[i].replace("$","x")
 
-        # sigma を np.sum にして各行の和とする（ただし、指定したパスが２次元配列以上でなければ値をそのまま返す）
+        # sigma を np.sum にして各行の和とする（ただし、指定したパスが２次元配列以上でなければエラーになる）
         pattern = r"sigma\((x\d+)\)"
-        replacement = r"np.sum(\1, axis=1) if \1.ndim > 1 else \1"
-        # sigmaを置換する際は文字列の中にif文を設けて、x1などの配列が2次元未満であれば値をそのまま返す
+        replacement = r"np.sum(\1, axis=1)"
+        
         # 置換を実行
         expression = re.sub(pattern, replacement, expression)
    


### PR DESCRIPTION
sigma計算時に$1が2次元配列以上の時、$2以降がelseの中に入り読み込まれていないため修正した。 sigmaに2次元配列配列未満の場合はエラーになるように戻した。